### PR TITLE
cask: vagrant174

### DIFF
--- a/vagrant174.rb
+++ b/vagrant174.rb
@@ -1,0 +1,14 @@
+cask 'vagrant174' do
+  version '1.7.4'
+  sha256 '3d2e680cc206ac1d480726052e42e193eabce56ed65fc79b91bc85e4c7d2deb8'
+
+  # bintray.com is the official download host per the vendor homepage
+  url "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{version}.dmg"
+  homepage 'http://www.vagrantup.com'
+  license :mit
+
+  pkg 'Vagrant.pkg'
+
+  uninstall script: { executable: 'uninstall.tool', input: ['Yes'] },
+            pkgutil: 'com.vagrant.vagrant'
+end


### PR DESCRIPTION
It looks like with the introduction of **vagrant 1.8.1** older versions of **vagrant** have been removed from the `caskroom-versions` tap. 

Reference: https://github.com/caskroom/homebrew-versions/pull/1515 and https://github.com/caskroom/homebrew-versions/pull/1518

It looks like `1.7.4` won't be added in either; so I'm adding this here for my projects that need it!

Simply run `brew tap jonmorehouse/tap` and `brew update` before attempting to install. 

To install `vagrant174`, once you've tapped and updated the repo you should be able to run `brew cask install vagrant174`